### PR TITLE
Fix opencl CMakeLists style check variable names

### DIFF
--- a/src/opencl12/aes_cl12/CMakeLists.txt
+++ b/src/opencl12/aes_cl12/CMakeLists.txt
@@ -61,9 +61,9 @@ endif( )
 ############################################################################
 
 # Style check
-set( check_target ${FOLDER_NAME}_check )
-set( check_target_src ${SRC_FILES} ${HEADER_FILES} ${TEST_FILES})
-add_style_check_target(${check_target} "${check_target_src}" "${SUBDIRECTORIES}")
+set( check_target ${BENCHMARK_NAME}_check )
+set( check_target_src ${SOURCE_FILES} ${HEADER_FILES} ${TEST_FILES})
+add_style_check_target(${check_target} "${check_target_src}" "")
 
 ############################################################################
 

--- a/src/opencl12/fir_cl12/CMakeLists.txt
+++ b/src/opencl12/fir_cl12/CMakeLists.txt
@@ -59,11 +59,11 @@ if( OPENCL_INCLUDE_DIRS STREQUAL "" OR OPENCL_LIBRARIES STREQUAL "")
 endif( )
 
 ############################################################################
-
+  
 # Style check
-set( check_target ${FOLDER_NAME}_check )
-set( check_target_src ${SRC_FILES} ${HEADER_FILES} ${TEST_FILES})
-add_style_check_target(${check_target} "${check_target_src}" "${SUBDIRECTORIES}")
+set( check_target ${BENCHMARK_NAME}_check )
+set( check_target_src ${SOURCE_FILES} ${HEADER_FILES} ${TEST_FILES})
+add_style_check_target(${check_target} "${check_target_src}" "")
 
 ############################################################################
 

--- a/src/opencl12/hmm_cl12/CMakeLists.txt
+++ b/src/opencl12/hmm_cl12/CMakeLists.txt
@@ -61,9 +61,9 @@ endif( )
 ############################################################################
 
 # Style check
-set( check_target ${FOLDER_NAME}_check )
-set( check_target_src ${SRC_FILES} ${HEADER_FILES} ${TEST_FILES})
-add_style_check_target(${check_target} "${check_target_src}" "${SUBDIRECTORIES}")
+set( check_target ${BENCHMARK_NAME}_check )
+set( check_target_src ${SOURCE_FILES} ${HEADER_FILES} ${TEST_FILES})
+add_style_check_target(${check_target} "${check_target_src}" "")
 
 ############################################################################
 

--- a/src/opencl12/iir_cl12/CMakeLists.txt
+++ b/src/opencl12/iir_cl12/CMakeLists.txt
@@ -61,9 +61,9 @@ endif( )
 ############################################################################
 
 # Style check
-set( check_target ${FOLDER_NAME}_check )
-set( check_target_src ${SRC_FILES} ${HEADER_FILES} ${TEST_FILES})
-add_style_check_target(${check_target} "${check_target_src}" "${SUBDIRECTORIES}")
+set( check_target ${BENCHMARK_NAME}_check )
+set( check_target_src ${SOURCE_FILES} ${HEADER_FILES} ${TEST_FILES})
+add_style_check_target(${check_target} "${check_target_src}" "")
 
 ############################################################################
 

--- a/src/opencl12/kmeans_cl12/CMakeLists.txt
+++ b/src/opencl12/kmeans_cl12/CMakeLists.txt
@@ -61,9 +61,9 @@ endif( )
 ############################################################################
 
 # Style check
-set( check_target ${FOLDER_NAME}_check )
-set( check_target_src ${SRC_FILES} ${HEADER_FILES} ${TEST_FILES})
-add_style_check_target(${check_target} "${check_target_src}" "${SUBDIRECTORIES}")
+set( check_target ${BENCHMARK_NAME}_check )
+set( check_target_src ${SOURCE_FILES} ${HEADER_FILES} ${TEST_FILES})
+add_style_check_target(${check_target} "${check_target_src}" "")
 
 ############################################################################
 

--- a/src/opencl12/pagerank_cl12/CMakeLists.txt
+++ b/src/opencl12/pagerank_cl12/CMakeLists.txt
@@ -60,9 +60,9 @@ endif( )
 ############################################################################
 
 # Style check
-set( check_target ${FOLDER_NAME}_check )
-set( check_target_src ${SRC_FILES} ${HEADER_FILES} ${TEST_FILES})
-add_style_check_target(${check_target} "${check_target_src}" "${SUBDIRECTORIES}")
+set( check_target ${BENCHMARK_NAME}_check )
+set( check_target_src ${SOURCE_FILES} ${HEADER_FILES} ${TEST_FILES})
+add_style_check_target(${check_target} "${check_target_src}" "")
 
 ############################################################################
 

--- a/src/opencl12/sw_cl12/CMakeLists.txt
+++ b/src/opencl12/sw_cl12/CMakeLists.txt
@@ -60,9 +60,9 @@ endif( )
 ############################################################################
 
 # Style check
-set( check_target ${FOLDER_NAME}_check )
-set( check_target_src ${SRC_FILES} ${HEADER_FILES} ${TEST_FILES})
-add_style_check_target(${check_target} "${check_target_src}" "${SUBDIRECTORIES}")
+set( check_target ${BENCHMARK_NAME}_check )
+set( check_target_src ${SOURCE_FILES} ${HEADER_FILES} ${TEST_FILES})
+add_style_check_target(${check_target} "${check_target_src}" "")
 
 ############################################################################
 

--- a/src/opencl20/aes_cl20/CMakeLists.txt
+++ b/src/opencl20/aes_cl20/CMakeLists.txt
@@ -61,9 +61,9 @@ endif( )
 ############################################################################
 
 # Style check
-set( check_target ${FOLDER_NAME}_check )
-set( check_target_src ${SRC_FILES} ${HEADER_FILES} ${TEST_FILES})
-add_style_check_target(${check_target} "${check_target_src}" "${SUBDIRECTORIES}")
+set( check_target ${BENCHMARK_NAME}_check )
+set( check_target_src ${SOURCE_FILES} ${HEADER_FILES} ${TEST_FILES})
+add_style_check_target(${check_target} "${check_target_src}" "")
 
 ############################################################################
 

--- a/src/opencl20/fir_cl20/CMakeLists.txt
+++ b/src/opencl20/fir_cl20/CMakeLists.txt
@@ -60,9 +60,9 @@ endif( )
 ############################################################################
 
 # Style check
-set( check_target ${FOLDER_NAME}_check )
-set( check_target_src ${SRC_FILES} ${HEADER_FILES} ${TEST_FILES})
-add_style_check_target(${check_target} "${check_target_src}" "${SUBDIRECTORIES}")
+set( check_target ${BENCHMARK_NAME}_check )
+set( check_target_src ${SOURCE_FILES} ${HEADER_FILES} ${TEST_FILES})
+add_style_check_target(${check_target} "${check_target_src}" "")
 
 ############################################################################
 

--- a/src/opencl20/hmm_cl20/CMakeLists.txt
+++ b/src/opencl20/hmm_cl20/CMakeLists.txt
@@ -61,9 +61,9 @@ endif( )
 ############################################################################
 
 # Style check
-set( check_target ${FOLDER_NAME}_check )
-set( check_target_src ${SRC_FILES} ${HEADER_FILES} ${TEST_FILES})
-add_style_check_target(${check_target} "${check_target_src}" "${SUBDIRECTORIES}")
+set( check_target ${BENCHMARK_NAME}_check )
+set( check_target_src ${SOURCE_FILES} ${HEADER_FILES} ${TEST_FILES})
+add_style_check_target(${check_target} "${check_target_src}" "")
 
 ############################################################################
 

--- a/src/opencl20/iir_cl20/CMakeLists.txt
+++ b/src/opencl20/iir_cl20/CMakeLists.txt
@@ -61,9 +61,9 @@ endif( )
 ############################################################################
 
 # Style check
-set( check_target ${FOLDER_NAME}_check )
-set( check_target_src ${SRC_FILES} ${HEADER_FILES} ${TEST_FILES})
-add_style_check_target(${check_target} "${check_target_src}" "${SUBDIRECTORIES}")
+set( check_target ${BENCHMARK_NAME}_check )
+set( check_target_src ${SOURCE_FILES} ${HEADER_FILES} ${TEST_FILES})
+add_style_check_target(${check_target} "${check_target_src}" "")
 
 ############################################################################
 

--- a/src/opencl20/kmeans_cl20/CMakeLists.txt
+++ b/src/opencl20/kmeans_cl20/CMakeLists.txt
@@ -61,9 +61,9 @@ endif( )
 ############################################################################
 
 # Style check
-set( check_target ${FOLDER_NAME}_check )
-set( check_target_src ${SRC_FILES} ${HEADER_FILES} ${TEST_FILES})
-add_style_check_target(${check_target} "${check_target_src}" "${SUBDIRECTORIES}")
+set( check_target ${BENCHMARK_NAME}_check )
+set( check_target_src ${SOURCE_FILES} ${HEADER_FILES} ${TEST_FILES})
+add_style_check_target(${check_target} "${check_target_src}" "")
 
 ############################################################################
 

--- a/src/opencl20/pagerank_cl20/CMakeLists.txt
+++ b/src/opencl20/pagerank_cl20/CMakeLists.txt
@@ -60,9 +60,9 @@ endif( )
 ############################################################################
 
 # Style check
-set( check_target ${FOLDER_NAME}_check )
-set( check_target_src ${SRC_FILES} ${HEADER_FILES} ${TEST_FILES})
-add_style_check_target(${check_target} "${check_target_src}" "${SUBDIRECTORIES}")
+set( check_target ${BENCHMARK_NAME}_check )
+set( check_target_src ${SOURCE_FILES} ${HEADER_FILES} ${TEST_FILES})
+add_style_check_target(${check_target} "${check_target_src}" "")
 
 ############################################################################
 

--- a/src/opencl20/sw_cl20/CMakeLists.txt
+++ b/src/opencl20/sw_cl20/CMakeLists.txt
@@ -60,9 +60,9 @@ endif( )
 ############################################################################
 
 # Style check
-set( check_target ${FOLDER_NAME}_check )
-set( check_target_src ${SRC_FILES} ${HEADER_FILES} ${TEST_FILES})
-add_style_check_target(${check_target} "${check_target_src}" "${SUBDIRECTORIES}")
+set( check_target ${BENCHMARK_NAME}_check )
+set( check_target_src ${SOURCE_FILES} ${HEADER_FILES} ${TEST_FILES})
+add_style_check_target(${check_target} "${check_target_src}" "")
 
 ############################################################################
 


### PR DESCRIPTION
If you have problem with make check to your benchmark, use make check -i to ignore errors. 
