### PR TITLE
Fixed filename and event_list removal

### DIFF
--- a/src/opencl12/fir_cl12/fir_cl12.cc
+++ b/src/opencl12/fir_cl12/fir_cl12.cc
@@ -120,8 +120,8 @@ void FIR::Run() {
   char *source_str;
   size_t source_size;
 
-  fp = fopen("fir_kernel_12.cl", "r");
-  if (!fp) { fp = fopen("src/opencl12/fir_cl12/fir_kernel_12.cl", "r"); }
+  fp = fopen("fir_cl12_kernel.cl", "r");
+  if (!fp) { fp = fopen("src/opencl12/fir_cl12/fir_cl12_kernel.cl", "r"); }
   if (!fp) {
     fprintf(stderr, "Failed to load kernel.\n");
     exit(1);
@@ -316,7 +316,6 @@ void FIR::Run() {
   /* comment to hide timing events */
   event_list->printEvents();
   event_list->dumpEvents((char *)"eventDumps");
-  delete event_list;
 
   diff = BILLION * (end.tv_sec - start.tv_sec) + end.tv_nsec - start.tv_nsec;
   printf("elapsed time = %llu nanoseconds\n", (long long unsigned int) diff);

--- a/src/opencl20/fir_cl20/fir_cl20.cc
+++ b/src/opencl20/fir_cl20/fir_cl20.cc
@@ -81,8 +81,8 @@ void FIR::Run() {
   char *source_str;
   size_t source_size;
 
-  fp = fopen("fir_kernel_20.cl", "r");
-  if (!fp) { fp = fopen("src/opencl20/fir_cl20/fir_kernel_20.cl", "r"); }
+  fp = fopen("fir_cl20_kernel.cl", "r");
+  if (!fp) { fp = fopen("src/opencl20/fir_cl20/fir_cl20_kernel.cl", "r"); }
   if (!fp) {
     fprintf(stderr, "Failed to load kernel.\n");
     exit(1);


### PR DESCRIPTION
Filenames of the kernels were changed without updating the main code and the statically declared event_list was deleted incorrectly.

Signed-off-by: Carter McCardwell carter@mccardwell.net
