### PR TITLE
Fix attempts to open incorrectly named .cl files in AES and SW.

### DIFF
--- a/src/opencl12/aes_cl12/aes_cl12.cc
+++ b/src/opencl12/aes_cl12/aes_cl12.cc
@@ -118,7 +118,7 @@ void AES::InitKernel() {
   append_str << "};\n";
 
   // Open kernel file
-  file->open("aes_cl12_Kernels.cl");
+  file->open("aes_cl12_kernel.cl");
 
   // Append kernel source code
   append_str << file->getSource();

--- a/src/opencl12/sw_cl12/sw_cl12.cc
+++ b/src/opencl12/sw_cl12/sw_cl12.cc
@@ -78,7 +78,7 @@ void ShallowWater::InitKernel() {
   cl_int err;
 
   // Open kernel file_
-  file_->open("sw_Kernels.cl");
+  file_->open("sw_cl12_kernel.cl");
 
   // Create program_
   const char *source = file_->getSourceChar();

--- a/src/opencl20/aes_cl20/aes_cl20.cc
+++ b/src/opencl20/aes_cl20/aes_cl20.cc
@@ -116,7 +116,7 @@ void AES::InitKernel() {
   append_str << "};\n";
 
   // Open kernel file
-  file->open("aes_Kernels.cl");
+  file->open("aes_cl20_kernel.cl");
 
   // Append kernel source code
   append_str << file->getSource();

--- a/src/opencl20/sw_cl20/sw_cl20.cc
+++ b/src/opencl20/sw_cl20/sw_cl20.cc
@@ -77,7 +77,7 @@ void ShallowWater::InitKernel() {
   cl_int err;
 
   // Open kernel file_
-  file_->open("sw_Kernels.cl");
+  file_->open("sw_cl20_kernel.cl");
 
   // Create program
   const char *source = file_->getSourceChar();


### PR DESCRIPTION
AES and SW try to open the wrong .cl files to get to their kernels. These files have been renamed in the Hetero-Mark repo and thus these benchmarks currently fail to run out of the box.
