### PR TITLE
More OpenCL 2.0 SVM Unmap/Free Fixes

### DIFF
--- a/src/opencl20/aes_cl20/aes_cl20.cc
+++ b/src/opencl20/aes_cl20/aes_cl20.cc
@@ -406,5 +406,8 @@ void AES::Run() {
     checkOpenCLErrors(err, "Failed at unmap SVM ptr");
   }  // While
 
+  // Make sure we have fully flushed all the unmap commands from the queue
+  // before we leaves here and eventually try to free this buffer.
+  clFinish(cmd_queue);
   fflush(outfile);
 }

--- a/src/opencl20/fir_cl20/fir_cl20.cc
+++ b/src/opencl20/fir_cl20/fir_cl20.cc
@@ -222,6 +222,7 @@ void FIR::Verify() {
 
 void FIR::Cleanup() {
   cl_int ret;
+  clFinish(cmd_queue_);
   ret = clReleaseKernel(fir_kernel_);
   ret = clReleaseProgram(program_);
   clSVMFree(context_, input_);

--- a/src/opencl20/hmm_cl20/hmm_cl20.cc
+++ b/src/opencl20/hmm_cl20/hmm_cl20.cc
@@ -364,6 +364,7 @@ void HMM::InitBuffers() {
 }
 
 void HMM::Cleanup() {
+  clFinish(cmdQueue_0);
   CleanUpKernels();
   CleanUpBuffers();
 }

--- a/src/opencl20/sw_cl20/sw_cl20.cc
+++ b/src/opencl20/sw_cl20/sw_cl20.cc
@@ -491,6 +491,7 @@ void ShallowWater::Run() {
 }
 
 void ShallowWater::Cleanup() {
+  clFinish(cmdQueue_);
   FreeBuffer();
   FreeKernel();
 }


### PR DESCRIPTION
This attempts to fix a series of potential problems in other benchmarks, like those described in #43.
