### PR TITLE
g++ compilation fixes

### DIFF
--- a/src/ep/ep_benchmark.cc
+++ b/src/ep/ep_benchmark.cc
@@ -40,6 +40,7 @@
 #include <cstdlib>
 #include <cstdio>
 #include <cmath>
+#include <algorithm>
 #include "src/ep/ep_benchmark.h"
 
 void EpBenchmark::Initialize() {

--- a/src/ga/ga_benchmark.cc
+++ b/src/ga/ga_benchmark.cc
@@ -39,6 +39,7 @@
 
 #include <cstdlib>
 #include <cstdio>
+#include <climits>
 #include <iostream>
 #include <fstream>
 #include <string>

--- a/src/pr/pr_benchmark.cc
+++ b/src/pr/pr_benchmark.cc
@@ -108,7 +108,7 @@ void PrBenchmark::Verify() {
   // Compare with GPU result
   bool has_error = false;
   for (i = 0; i < num_nodes_; i++) {
-    if (isnan(page_rank_[i]) ||
+    if (std::isnan(page_rank_[i]) ||
         fabs(page_rank_[i] - cpu_page_rank[i]) > cpu_page_rank[i] / 1000) {
       printf("Error with node %i, expected to be %e, but was %e\n", i,
              cpu_page_rank[i], page_rank_[i]);


### PR DESCRIPTION
g++ 6.3 was throwing errors for missing includes.  I've added the respective headers.